### PR TITLE
WP_Term: Avoid deprecated warnings on WP_Term with PHP8.2

### DIFF
--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -14,7 +14,6 @@
  *
  * @property-read object $data Sanitized term data.
  */
-#[AllowDynamicProperties]
 final class WP_Term {
 
 	/**
@@ -88,6 +87,62 @@ final class WP_Term {
 	 * @var int
 	 */
 	public $count = 0;
+
+	/**
+	 * Object ID (for compatibility with the old taxonomy API).
+	 *
+	 * @var int|null
+	 */
+	public $object_id = null;
+
+	/**
+	 * Compatibility fields (for compatibility with the old taxonomy API).
+	 *
+	 * @var array
+	 */
+	public $compat_fields = array();
+
+	/**
+	 * Category ID (for compatibility with the old taxonomy API).
+	 *
+	 * @var int|null
+	 */
+	public $cat_ID = null;
+
+	/**
+	 * Category count (for compatibility with the old taxonomy API).
+	 *
+	 * @var int|null
+	 */
+	public $category_count = null;
+
+	/**
+	 * Category description (for compatibility with the old taxonomy API).
+	 *
+	 * @var string|null
+	 */
+	public $category_description = null;
+
+	/**
+	 * Category name (for compatibility with the old taxonomy API).
+	 *
+	 * @var string|null
+	 */
+	public $cat_name = null;
+
+	/**
+	 * Category slug (for compatibility with the old taxonomy API).
+	 *
+	 * @var string|null
+	 */
+	public $category_nicename = null;
+
+	/**
+	 * Category parent ID (for compatibility with the old taxonomy API).
+	 *
+	 * @var int|null
+	 */
+	public $category_parent = null;
 
 	/**
 	 * Stores the term object's sanitization level.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

WP version: 6.8
PHP version: 8.2
Environment: Official Docker image with WP_UnitTest

Adding a unit test environment using WP_UnitTests, xdebug throws several
`Deprecated: Creation of dynamic property WP_Term::$category_description is deprecated` warnings.

The issue points to the `_make_cat_compat` function because it tries to assign values ​​to object properties that are not defined in `WP_Term`.

I suggest defining the old properties on WP_Terms

```
Deprecated: Creation of dynamic property WP_Term::$cat_name is deprecated in /var/www/html/wp-content/themes/themename/tests/wordpress-develop/src/wp-includes/category.php on line 381

Deprecated: Creation of dynamic property WP_Term::$category_nicename is deprecated in /var/www/html/wp-content/themes/themename/tests/wordpress-develop/src/wp-includes/category.php on line 382

Deprecated: Creation of dynamic property WP_Term::$category_parent is deprecated in /var/www/html/wp-content/themes/themename/tests/wordpress-develop/src/wp-includes/category.php on line 383
 ✔ Exclude ab test from query method

Deprecated: Creation of dynamic property WP_Term::$cat_ID is deprecated in /var/www/html/wp-content/themes/themename/tests/wordpress-develop/src/wp-includes/category.php on line 378

Deprecated: Creation of dynamic property WP_Term::$category_count is deprecated in /var/www/html/wp-content/themes/themename/tests/wordpress-develop/src/wp-includes/category.php on line 379

Deprecated: Creation of dynamic property WP_Term::$category_description is deprecated in /var/www/html/wp-content/themes/themename/tests/wordpress-develop/src/wp-includes/category.php on line 380

Deprecated: Creation of dynamic property WP_Term::$cat_name is deprecated in /var/www/html/wp-content/themes/themename/tests/wordpress-develop/src/wp-includes/category.php on line 381
```

After the fix:

```
AB_Test_Post_ (ThemeName\Tests\Theme\Growth\AB_Test_Post_)
 ✔ Alter post query method
 ✔ Add ab test post meta
 ✔ Maybe add no index meta tag method
 ✔ Render ab test settings meta box method
 ✔ Exclude ab test from query method
 ✔ Save ab test settings
 ✔ Add canonical url
```

Trac ticket: https://core.trac.wordpress.org/ticket/63521#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
